### PR TITLE
Fix: Load existing logins when adding a new one to prevent replacing the old login providers

### DIFF
--- a/src/AspNetCore.Identity.AmazonDynamoDB/Stores/DynamoDbUserStore.cs
+++ b/src/AspNetCore.Identity.AmazonDynamoDB/Stores/DynamoDbUserStore.cs
@@ -86,12 +86,12 @@ public class DynamoDbUserStore<TUserEntity> :
     }
   }
 
-  public Task AddLoginAsync(TUserEntity user, UserLoginInfo login, CancellationToken cancellationToken)
+  public async Task AddLoginAsync(TUserEntity user, UserLoginInfo login, CancellationToken cancellationToken)
   {
     ArgumentNullException.ThrowIfNull(user);
     ArgumentNullException.ThrowIfNull(login);
 
-    user.Logins ??= new();
+    user.Logins = await GetRawLogins(user, cancellationToken);
 
     user.Logins.Add(new DynamoDbUserLogin
     {
@@ -100,8 +100,6 @@ public class DynamoDbUserStore<TUserEntity> :
       ProviderDisplayName = login.ProviderDisplayName,
       UserId = user.Id,
     });
-
-    return Task.CompletedTask;
   }
 
   public Task AddToRoleAsync(TUserEntity user, string roleName, CancellationToken cancellationToken)

--- a/test/AspNetCore.Identity.AmazonDynamoDB.Tests/Stores/DynamoDbUserStoreTests.cs
+++ b/test/AspNetCore.Identity.AmazonDynamoDB.Tests/Stores/DynamoDbUserStoreTests.cs
@@ -208,6 +208,31 @@ public class DynamoDbUserStoreTests
   }
 
   [Fact]
+  public async Task Should_AddSecondLoginProvider_When_UserExists()
+  {
+    // Arrange
+    var context = new DynamoDBContext(DatabaseFixture.Client);
+    var options = TestUtils.GetOptions(new() { Database = DatabaseFixture.Client });
+    var userStore = new DynamoDbUserStore<DynamoDbUser>(options);
+    await AspNetCoreIdentityDynamoDbSetup.EnsureInitializedAsync(options);
+    var user = new DynamoDbUser();
+    var login = new DynamoDbUserLogin
+    {
+      LoginProvider = "first",
+      ProviderKey = "first",
+      UserId = user.Id,
+    };
+    await context.SaveAsync(login);
+
+    // Act
+    await userStore.AddLoginAsync(
+      user, new("second", "second", "second"), CancellationToken.None);
+
+    // Assert
+    Assert.Equal(2, user.Logins!.Count);
+  }
+
+  [Fact]
   public async Task Should_ThrowException_When_TryingToAddRoleToAUserThatIsNull()
   {
     // Arrange


### PR DESCRIPTION
Resolves #49 